### PR TITLE
Fix bug that caused type tree to lose types

### DIFF
--- a/src/ReactiveDomain.Messaging.Tests/when_rebuilding_message_hierarchy.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_rebuilding_message_hierarchy.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using ReactiveDomain.Messaging.Bus;
+using Xunit;
+
+namespace ReactiveDomain.Messaging.Tests
+{
+    // ReSharper disable InconsistentNaming
+    public class when_rebuilding_message_hierarchy
+    {
+        sealed class TestMsg : Message { }
+
+        [Fact]
+        public void in_memory_bus_remembers_handlers()
+        {
+            var method = typeof(MessageHierarchy).GetMethod("RebuildMessageTree", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var bus = InMemoryBus.CreateTest();
+
+            var fired = false;
+            bus.Subscribe(new AdHocHandler<TestMsg>(m => fired = true));
+            
+            bus.Publish(new TestMsg());
+            Assert.True(fired);
+
+            // ReSharper disable once PossibleNullReferenceException
+            method.Invoke(null, new object[0]);
+
+            fired = false;
+            bus.Publish(new TestMsg());
+            Assert.True(fired);
+        }
+    }
+    // ReSharper restore InconsistentNaming
+}

--- a/src/ReactiveDomain.Messaging/MessageHierarchy.cs
+++ b/src/ReactiveDomain.Messaging/MessageHierarchy.cs
@@ -71,7 +71,7 @@ namespace ReactiveDomain.Messaging
                 addedTypes.ForEach(t => fullNameToType[t.FullName] = t);
                 if (addedTypes.FirstOrDefault() != null)
                 {
-                    TypeTree.ResetTypeTree(addedTypes);
+                    TypeTree.AddToTypeTree(addedTypes);
                     MessageTypesAdded(null, null);
                 }
             }
@@ -147,13 +147,14 @@ namespace ReactiveDomain.Messaging
             BuildTypeTree(types);
         }
 
-        internal static void ResetTypeTree(List<Type> types)
+        internal static void AddToTypeTree(List<Type> types)
         {
             // Rebuild the type tree. Lock in case multiple overlapping resets are called.
             lock (_loadingLock)
             {
+                var typeList = types.Concat(_typeToNode.Keys).ToList();
                 _typeToNode = new Dictionary<Type, TypeTreeNode>();
-                BuildTypeTree(types);
+                BuildTypeTree(typeList);
             }
         }
 

--- a/src/ReactiveDomain.Messaging/MessageHierarchy.cs
+++ b/src/ReactiveDomain.Messaging/MessageHierarchy.cs
@@ -62,18 +62,23 @@ namespace ReactiveDomain.Messaging
 
         private static void AssemblyLoadEventHandler(object sender, AssemblyLoadEventArgs args)
         {
-            // TODO: Comment on this if condition.
+            // don't load dynamic assembles or non-bin assemblies for security and complexity concerns respectively
             if (!args.LoadedAssembly.IsDynamic && args.LoadedAssembly.Location.Contains(AppDomain.CurrentDomain.BaseDirectory))
             {
-                var addedTypes = GetTypesDerivedFrom(typeof(Message));
-                // Update lookups for name and fullnames
-                addedTypes.ForEach(t => nameToType[t.Name] = t);
-                addedTypes.ForEach(t => fullNameToType[t.FullName] = t);
-                if (addedTypes.FirstOrDefault() != null)
-                {
-                    TypeTree.AddToTypeTree(addedTypes);
-                    MessageTypesAdded(null, null);
-                }
+                RebuildMessageTree();
+            }
+        }
+
+        private static void RebuildMessageTree()
+        {
+            var addedTypes = GetTypesDerivedFrom(typeof(Message));
+            // Update lookups for name and fullnames
+            addedTypes.ForEach(t => nameToType[t.Name] = t);
+            addedTypes.ForEach(t => fullNameToType[t.FullName] = t);
+            if (addedTypes.FirstOrDefault() != null)
+            {
+                TypeTree.AddToTypeTree(addedTypes);
+                MessageTypesAdded(null, null);
             }
         }
 
@@ -137,7 +142,7 @@ namespace ReactiveDomain.Messaging
         }
     }
 
-    internal static class TypeTree
+    internal static class TypeTree  
     {
         private static TypeTreeNode _root;
         private static Dictionary<Type, TypeTreeNode> _typeToNode = new Dictionary<Type, TypeTreeNode>();


### PR DESCRIPTION
If assemblies are delay loaded, then the type tree is reset using only 
the newly loaded types, causing any previous types to be lost from
the tree.

This was causing issues for Master Data project, where the AckCommand
and CommandResponse handlers were never firing.