### PR TITLE
Reuse the same framer across receive callbacks for a given connection

### DIFF
--- a/src/ReactiveDomain.Transport.Tests/TcpBusServerSideTests.cs
+++ b/src/ReactiveDomain.Transport.Tests/TcpBusServerSideTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using Xunit;
+
+namespace ReactiveDomain.Transport.Tests
+{
+    public class TcpBusServerSideTests
+    {
+        [Fact]
+        public void can_handle_split_frames()
+        {
+            // 16kb large enough to cause the transport to split up the frame.
+            // it would be better if we did the splitting manually so we were sure it really happened.
+            // would require mocking more things.
+            var hostAddress = IPAddress.Loopback;
+            var prop1 = "prop1";
+            var prop2 = string.Join("", Enumerable.Repeat("a", 16 * 1024));
+            var port = 10000;
+            var tcs = new TaskCompletionSource<Message>();
+
+            // server side
+            var serverInbound = new QueuedHandler(
+                new AdHocHandler<Message>(tcs.SetResult),
+                "InboundMessageQueuedHandler",
+                true,
+                TimeSpan.FromMilliseconds(1000));
+
+            var tcpBusServerSide = new TcpBusServerSide(hostAddress, port, null)
+            {
+                InboundMessageQueuedHandler = serverInbound,
+                InboundSpamMessageTypes = new List<Type>(),
+            };
+
+            serverInbound.Start();
+
+            // client side
+            var tcpBusClientSide = new TcpBusClientSide(null, hostAddress, port);
+
+            // wait for tcp connection to be established (maybe an api to detect this would be nice)
+            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+
+            // put message into client
+            tcpBusClientSide.Handle(new WoftamEvent(prop1, prop2));
+
+            // expect to receive it in the server
+            var gotMessage = tcs.Task.Wait(TimeSpan.FromMilliseconds(1000));
+            Assert.True(gotMessage);
+            var evt = Assert.IsType<WoftamEvent>(tcs.Task.Result);
+            Assert.Equal(prop1, evt.Property1);
+            Assert.Equal(prop2, evt.Property2);
+        }
+    }
+}

--- a/src/ReactiveDomain.Transport/TcpBusServerSide.cs
+++ b/src/ReactiveDomain.Transport/TcpBusServerSide.cs
@@ -25,11 +25,12 @@ namespace ReactiveDomain.Transport
             {
                var conn = Transport.TcpConnection.CreateAcceptedTcpConnection(Guid.NewGuid(), endPoint, socket, verbose: true);
 
+                LengthPrefixMessageFramer framer = new LengthPrefixMessageFramer();
+                framer.RegisterMessageArrivedCallback(TcpMessageArrived);
+
                 Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback = null;
                 callback = (x, data) =>
                 {
-                    LengthPrefixMessageFramer framer = new LengthPrefixMessageFramer();
-                    framer.RegisterMessageArrivedCallback(TcpMessageArrived);
                     try
                     {
                         framer.UnFrameData(data);


### PR DESCRIPTION
Otherwise, if the the frame is received in pieces, the new framer will
not know, and incorrectly try to read a header in the middle of a
frame.

This bug was introduced in commit
f6dbf4dfaadf47fc646a63cda502fbc2a3bb0c81 when TcpBusSide gained multiple
connections instead of one. It looks like the idea in constructing the
new framer was to stop the framer from being shared between connections.

I have placed the framer construction so that each connection has its
own, and reuses it on each receive. I have also added a unit test
that reproduces the bug.