### PR TITLE
Remove BSON dependency from RD.Transport

### DIFF
--- a/src/ReactiveDomain.Transport.Tests/can_serialize_messages.cs
+++ b/src/ReactiveDomain.Transport.Tests/can_serialize_messages.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Bson;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Transport.CommandSocket;
 using Xunit;
@@ -10,92 +9,6 @@ namespace ReactiveDomain.Transport.Tests
     // ReSharper disable InconsistentNaming
     public class when_creating_tcp_messages
     {
-        [Fact]
-        public void bson_serialize_object_test()
-        {
-            var propName = "Value";
-            var propValue = "Dummy";
-            MemoryStream ms = new MemoryStream();
-            var bs = new BsonDataWriter(ms);
-            bs.WriteStartObject();
-            bs.WritePropertyName(propName);
-            bs.WriteValue(propValue);
-            bs.WriteEnd();
- 
-            ms.Seek(0, SeekOrigin.Begin);
- 
-            var reader = new BsonDataReader(ms);
-            // object
-            reader.Read();
-            // property name
-            reader.Read();
-            Assert.Equal(propName, (string) reader.Value);
-            reader.Read();
-            Assert.Equal(propValue, (string) reader.Value);
-        }
-        [Fact]
-        public void bson_serialize_message_test()
-        {
-            var prop1 = "prop1";
-            var prop2 = "prop2";
-            var msg = new WoftamEvent(prop1,prop2);
-            MemoryStream ms = new MemoryStream();
-            var bs = new BsonDataWriter(ms);
-            bs.WriteStartObject();
-            bs.WritePropertyName(msg.GetType().FullName);
-            bs.WriteValue(JsonConvert.SerializeObject(msg));
-            bs.WriteEnd();
- 
-            ms.Seek(0, SeekOrigin.Begin);
-            Message msg2;
-            var reader = new BsonDataReader(ms);
-            // read object
-            reader.Read();
-            // read type name
-            reader.Read();
-            var messageType = MessageHierarchy.GetTypeByFullName((string)reader.Value);
-            reader.Read(); //property value
-            msg2 = (Message)JsonConvert.DeserializeObject((string)reader.Value, messageType);
-            Assert.IsType<WoftamEvent>(msg2);
-            Assert.Equal(prop1,((WoftamEvent)msg2).Property1);
-        }
-
-        [Fact]
-        public void can_create_tcp_message_from_message()
-        {
-            var tcpMsg = new TcpMessage(_testEvent);
-            Assert.NotNull(tcpMsg.Data.Array);
-            // ReSharper disable once AssignNullToNotNullAttribute
-            var reader = new BsonDataReader(new MemoryStream(tcpMsg.Data.Array));
-            // read object
-            reader.Read();
-            // read type name
-            reader.Read();
-            var messageType = MessageHierarchy.GetTypeByFullName((string)reader.Value);
-            reader.Read(); //read json value
-            var msg2 = (Message)JsonConvert.DeserializeObject((string)reader.Value, messageType, Json.JsonSettings);
-            Assert.IsType<WoftamEvent>(msg2);
-            Assert.Equal(Prop1,((WoftamEvent)msg2).Property1);
-        }
-
-        [Fact]
-        public void can_create_tcp_message_from_byte_array()
-        {
-            var tcpMsg = new TcpMessage(_testEvent);
-            Assert.NotNull(tcpMsg.Data.Array);
-            // ReSharper disable once AssignNullToNotNullAttribute
-            var reader = new BsonDataReader(new MemoryStream(tcpMsg.Data.Array));
-            // read object
-            reader.Read();
-            // read type name
-            reader.Read();
-            var messageType = MessageHierarchy.GetTypeByFullName((string)reader.Value);
-            reader.Read(); //read json value
-            var msg2 = (Message)JsonConvert.DeserializeObject((string)reader.Value, messageType, Json.JsonSettings);
-            Assert.IsType<WoftamEvent>(msg2);
-            Assert.Equal(Prop1,((WoftamEvent)msg2).Property1);
-        }
-
         [Fact]
         public void can_serialize_from_message()
         {

--- a/src/ReactiveDomain.Transport/CommandSocket/TcpMessage.cs
+++ b/src/ReactiveDomain.Transport/CommandSocket/TcpMessage.cs
@@ -1,23 +1,17 @@
 ﻿using System;
-using System.IO;
+using System.Text;
 using Newtonsoft.Json;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Logging;
 using ReactiveDomain.Util;
 using Settings = ReactiveDomain.Messaging.Json;
-#if !NET40
-using BsonDataReader = Newtonsoft.Json.Bson.BsonDataReader;
-using BsonDataWriter = Newtonsoft.Json.Bson.BsonDataWriter;
-#else
-using BsonDataReader = Newtonsoft.Json.Bson.BsonReader;
-using BsonDataWriter = Newtonsoft.Json.Bson.BsonWriter;
-#endif
 
 namespace ReactiveDomain.Transport.CommandSocket
 {
-	public struct TcpMessage
+    public struct TcpMessage
     {
         private static readonly ILogger Log = LogManager.GetLogger("ReactiveDomain");
+        private static readonly Encoding Encoding = Encoding.UTF8;
         public readonly Type MessageType;
         public readonly ArraySegment<byte> Data;
         public readonly Message WrappedMessage;
@@ -34,21 +28,19 @@ namespace ReactiveDomain.Transport.CommandSocket
             if (data.Array == null || data.Count < sizeof(int))
                 throw new ArgumentException($"ArraySegment null or too short, length: {data.Count}", nameof(data));
 
-            Message msg;
-#pragma warning disable 618
-            using (var reader = new BsonDataReader(new MemoryStream(data.Array)))
-#pragma warning restore 618
-            {
-                reader.Read(); //object
-                reader.Read(); //property name
+            var offset = data.Offset;
+            offset += ReadBytes(data.Array, offset, out var typeNameByteCount);
+            offset += ReadBytes(data.Array, offset, typeNameByteCount, out var typeName);
+            offset += ReadBytes(data.Array, offset, out var jsonByteCount);
+            ReadBytes(data.Array, offset, jsonByteCount, out var json);
 
-                var messageType = MessageHierarchy.GetTypeByFullName((string)reader.Value);
-                reader.Read(); //property value
-                msg = (Message)JsonConvert.DeserializeObject((string)reader.Value, messageType, Settings.JsonSettings);
-            }
+            var messageType = MessageHierarchy.GetTypeByFullName(typeName);
+            var msg = (Message)JsonConvert.DeserializeObject(json, messageType, Settings.JsonSettings);
+
             Log.Debug("Deserialized Message MsgId=" + msg.MsgId + " MsgType" + msg.GetType().Name);
             return new TcpMessage(msg, data);
         }
+
         //used by FromArraySegment to set the values and return the struct
         private TcpMessage(Message message, ArraySegment<byte> data)
         {
@@ -67,19 +59,49 @@ namespace ReactiveDomain.Transport.CommandSocket
             MessageType = message.GetType();
             Log.Debug("Message MsgId=" + message.MsgId + " MsgTypeId=" + message.GetType().Name + " to be wrapped.");
 
-            var ms = new MemoryStream();
-#pragma warning disable 618
-            using (var writer = new BsonDataWriter(ms))
-#pragma warning restore 618
-            {
-                writer.WriteStartObject();
-                writer.WritePropertyName(MessageType.FullName);
-                writer.WriteValue(JsonConvert.SerializeObject(message, Settings.JsonSettings));
-                writer.WriteEnd();
-            }
-            Data = new ArraySegment<byte>(ms.ToArray());
+            var typeName = MessageType.FullName;
+            var json = JsonConvert.SerializeObject(message, Settings.JsonSettings);
+
+            var typeNameByteCount = Encoding.GetByteCount(typeName);
+            var jsonByteCount = Encoding.GetByteCount(json);
+            var totalByteCount = sizeof(int) + typeNameByteCount + sizeof(int) + jsonByteCount;
+
+            var array = new byte[totalByteCount];
+            Data = new ArraySegment<byte>(array);
+
+            var offset = 0;
+            offset += WriteBytes(typeNameByteCount, array, offset);
+            offset += WriteBytes(typeName, array, offset);
+            offset += WriteBytes(jsonByteCount, array, offset);
+            WriteBytes(json, array, offset);
+
             WrappedMessage = message;
         }
-    }
 
+        private static int ReadBytes(byte[] source, int offset, out int destination)
+        {
+            destination = BitConverter.ToInt32(source, offset);
+            return sizeof(int);
+        }
+
+        private static int WriteBytes(int source, byte[] destination, int offset)
+        {
+            destination[offset + 0] = (byte)source;
+            destination[offset + 1] = (byte)(source >> 8);
+            destination[offset + 2] = (byte)(source >> 16);
+            destination[offset + 3] = (byte)(source >> 24);
+            return sizeof(int);
+        }
+
+        private static int ReadBytes(byte[] source, int offset, int count, out string destination)
+        {
+            destination = Encoding.GetString(source, offset, count);
+            return count;
+        }
+
+        private static int WriteBytes(string source, byte[] destination, int offset)
+        {
+            return Encoding.GetBytes(source, 0, source.Length, destination, offset);
+        }
+    }
 }

--- a/src/ReactiveDomain.Transport/CommandSocket/TcpMessage.cs
+++ b/src/ReactiveDomain.Transport/CommandSocket/TcpMessage.cs
@@ -11,7 +11,7 @@ namespace ReactiveDomain.Transport.CommandSocket
     public struct TcpMessage
     {
         private static readonly ILogger Log = LogManager.GetLogger("ReactiveDomain");
-        private static readonly Encoding Encoding = Encoding.UTF8;
+        private static readonly Encoding Encoding = Helper.UTF8NoBom;
         public readonly Type MessageType;
         public readonly ArraySegment<byte> Data;
         public readonly Message WrappedMessage;

--- a/src/ReactiveDomain.Transport/ReactiveDomain.Transport.csproj
+++ b/src/ReactiveDomain.Transport/ReactiveDomain.Transport.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <BuildWithNet40>true</BuildWithNet40>
   </PropertyGroup>
@@ -9,7 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" Condition="'$(TargetFramework)'!='net40'" />
-    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" Condition="'$(TargetFramework)'!='net40'" />
     <Reference Include="Microsoft.CSharp" Condition="'$(TargetFramework)'=='net40'" />
     <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
     <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />


### PR DESCRIPTION
This is a breaking change in the TcpMessage serialization - both sides
of the connection would have to be upgraded.

Motivation
- Fewer dependencies are better. We were only using BSON to serialize
a string, we can do that ourselves.
- Removes complications around NET40 conditional compilation
- As a happy side effect, this is 2x faster for small messages

The strings themselves are encoded with UTF8 both before and after, so
problems arising from encoding are not anticipated.

I have removed 3 unit tests that seem to me to be coupled to the
implementation details.