### PR TITLE
Fix race condition where fast connect prevents receiving

### DIFF
--- a/src/ReactiveDomain.Transport/TcpBusClientSide.cs
+++ b/src/ReactiveDomain.Transport/TcpBusClientSide.cs
@@ -34,7 +34,7 @@ namespace ReactiveDomain.Transport
                 {
                     Log.Info("TcpBusClientSide.CreateTcpConnection(" + endPoint.Address + ":" + endPoint.Port + ") successfully constructed TcpConnection.");
 
-                    ConfigureTcpListener();
+                    ConfigureTcpListener(conn);
                 },
                 (conn, err) =>
                 {
@@ -56,7 +56,7 @@ namespace ReactiveDomain.Transport
         }
 
 
-        private void ConfigureTcpListener()
+        private void ConfigureTcpListener(ITcpConnection conn)
         {
             Framer.RegisterMessageArrivedCallback(TcpMessageArrived);
             Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback = null;
@@ -72,9 +72,9 @@ namespace ReactiveDomain.Transport
                     // SendBadRequestAndClose(Guid.Empty, string.Format("Invalid TCP frame received. Error: {0}.", exc.Message));
                     return;
                 }
-                TcpConnection[0].ReceiveAsync(callback); //client should only have one connection
+                conn.ReceiveAsync(callback);
             };
-            TcpConnection[0].ReceiveAsync(callback); //client should only have one connection
+            conn.ReceiveAsync(callback);
         }
 
     }


### PR DESCRIPTION
ConfigureTcpListener expects TcpConnection (the list) to have one
connection in it. But we do not add it until we have finished
calling CreateTcpConnection() on line 23.

If the connection is established quickly then ConfigureTcpListener
can be called before the connection is added to the list, and so
ReceiveAsync will not be called for that connection.

I have fixed this by passing the connection into
ConfigureTcpListener instead of expecting it to be in the list.