### PR TITLE
Use EndPoint for TCP connections.

### DIFF
--- a/src/ReactiveDomain.Transport.Tests/MockTcpConnection.cs
+++ b/src/ReactiveDomain.Transport.Tests/MockTcpConnection.cs
@@ -7,7 +7,7 @@ namespace ReactiveDomain.Transport.Tests
 {
     public class MockTcpConnection : ITcpConnection
     {
-        private static IPEndPoint _remoteEndPoint;
+        private static EndPoint _remoteEndPoint;
         private static Guid _connectionId;
 
         public static MockTcpConnection CreateConnectingTcpConnection(Guid connectionId,
@@ -23,7 +23,7 @@ namespace ReactiveDomain.Transport.Tests
             return new MockTcpConnection();
         }
 
-        public static MockTcpConnection CreateAcceptedTcpConnection(Guid connectionId, IPEndPoint remoteEndPoint, Socket socket, bool verbose)
+        public static MockTcpConnection CreateAcceptedTcpConnection(Guid connectionId, EndPoint remoteEndPoint, Socket socket, bool verbose)
         {
             throw new NotImplementedException();
         }
@@ -32,9 +32,9 @@ namespace ReactiveDomain.Transport.Tests
 
         public Guid ConnectionId => _connectionId;
 
-        public IPEndPoint RemoteEndPoint => _remoteEndPoint;
+        public EndPoint RemoteEndPoint => _remoteEndPoint;
 
-        public IPEndPoint LocalEndPoint => null;
+        public EndPoint LocalEndPoint => null;
 
         public int SendQueueSize
         {

--- a/src/ReactiveDomain.Transport/ITcpConnection.cs
+++ b/src/ReactiveDomain.Transport/ITcpConnection.cs
@@ -38,8 +38,8 @@ namespace ReactiveDomain.Transport
         event Action<ITcpConnection, SocketError> ConnectionClosed;
 
         Guid ConnectionId { get; }
-        IPEndPoint RemoteEndPoint { get; }
-        IPEndPoint LocalEndPoint { get; }
+        EndPoint RemoteEndPoint { get; }
+        EndPoint LocalEndPoint { get; }
         int SendQueueSize { get; }
         bool IsInitialized { get; }
         bool IsClosed { get; }

--- a/src/ReactiveDomain.Transport/TcpBusClientSide.cs
+++ b/src/ReactiveDomain.Transport/TcpBusClientSide.cs
@@ -9,8 +9,15 @@ using ReactiveDomain.Messaging.Bus;
 namespace ReactiveDomain.Transport
 {
     public class TcpBusClientSide : TcpBusSide
-
     {
+        public TcpBusClientSide(
+            IDispatcher messageBus,
+            EndPoint endpoint,
+            ITcpConnection tcpConnection = null)
+            : base(endpoint, messageBus)
+        {
+            TcpConnection.Add(tcpConnection ?? CreateTcpConnection(CommandEndpoint));
+        }
 
         public TcpBusClientSide(
             IDispatcher messageBus,
@@ -23,16 +30,16 @@ namespace ReactiveDomain.Transport
             TcpConnection.Add(tcpConnection ?? CreateTcpConnection(CommandEndpoint));
         }
 
-        private ITcpConnection CreateTcpConnection(IPEndPoint endPoint)
+        private ITcpConnection CreateTcpConnection(EndPoint endPoint)
         {
-            Log.Info("TcpBusClientSide.CreateTcpConnection(" + endPoint.Address + ":" + endPoint.Port + ") entered.");
+            Log.Info("TcpBusClientSide.CreateTcpConnection(" + endPoint + ") entered.");
             var clientTcpConnection = Transport.TcpConnection.CreateConnectingTcpConnection(Guid.NewGuid(),
                 endPoint,
                 new TcpClientConnector(),
                 TimeSpan.FromSeconds(120),
                 conn =>
                 {
-                    Log.Info("TcpBusClientSide.CreateTcpConnection(" + endPoint.Address + ":" + endPoint.Port + ") successfully constructed TcpConnection.");
+                    Log.Info("TcpBusClientSide.CreateTcpConnection(" + endPoint + ") successfully constructed TcpConnection.");
 
                     ConfigureTcpListener();
                 },

--- a/src/ReactiveDomain.Transport/TcpBusServerSide.cs
+++ b/src/ReactiveDomain.Transport/TcpBusServerSide.cs
@@ -17,7 +17,7 @@ namespace ReactiveDomain.Transport
             : base(hostIp, commandPort, messageBus)
         {
            
-            Log.Info("ConfigureTcpListener(" + CommandEndpoint.AddressFamily + ", " + CommandEndpoint.Port + ") entered.");
+            Log.Info("ConfigureTcpListener(" + CommandEndpoint.AddressFamily + ", " + CommandEndpoint + ") entered.");
             
             var listener = new TcpServerListener(CommandEndpoint);
 
@@ -45,7 +45,7 @@ namespace ReactiveDomain.Transport
                 conn.ReceiveAsync(callback);
                 TcpConnection.Add(conn);
             }, "Standard");
-            Log.Info("ConfigureTcpListener(" + CommandEndpoint.AddressFamily + ", " + CommandEndpoint.Port + ") successfully constructed TcpServerListener.");
+            Log.Info("ConfigureTcpListener(" + CommandEndpoint.AddressFamily + ", " + CommandEndpoint + ") successfully constructed TcpServerListener.");
             _commandPortListener = listener;
         }
     }

--- a/src/ReactiveDomain.Transport/TcpBusSide.cs
+++ b/src/ReactiveDomain.Transport/TcpBusSide.cs
@@ -25,32 +25,22 @@ namespace ReactiveDomain.Transport
             IPAddress hostIp,
             int commandPort,
             IDispatcher messageBus)
+            : this(new IPEndPoint(hostIp, commandPort), messageBus)
+        { }
+
+        protected TcpBusSide(
+            EndPoint endpoint,
+            IDispatcher messageBus)
         {
-            _hostIp = hostIp;
-            _commandPort = commandPort;
+            CommandEndpoint = endpoint;
             MessageBus = messageBus;
             StatsTimer = new Timer(60000);             // getting the stats takes a while - only do it once a minute
             StatsTimer.Elapsed += _statsTimer_Elapsed;
             StatsTimer.Enabled = true;
         }
 
-        /// <summary>
-        /// IP address of the Host application
-        /// </summary>        
-        private IPAddress _hostIp;
-        private int _commandPort;
+        public EndPoint CommandEndpoint { get; }
 
-        public IPEndPoint CommandEndpoint
-        {
-            get
-            {
-                if (_commandEndpoint == null)
-                    _commandEndpoint = new IPEndPoint(_hostIp, _commandPort);
-                return _commandEndpoint;
-            }
-        }
-
-        private IPEndPoint _commandEndpoint;
         public List<Type> InboundSpamMessageTypes
         {
             set { _inboundSpamMessageTypes = value; }

--- a/src/ReactiveDomain.Transport/TcpClientConnector.cs
+++ b/src/ReactiveDomain.Transport/TcpClientConnector.cs
@@ -45,7 +45,7 @@ namespace ReactiveDomain.Transport
         }
 
         public ITcpConnection ConnectSslTo(Guid connectionId,
-                                           IPEndPoint remoteEndPoint,
+                                           EndPoint remoteEndPoint,
                                            TimeSpan connectionTimeout,
                                            string targetHost,
                                            bool validateServer,
@@ -59,9 +59,9 @@ namespace ReactiveDomain.Transport
                                                                this, connectionTimeout, onConnectionEstablished, onConnectionFailed, verbose);
         }
 
-        internal void InitConnect(IPEndPoint serverEndPoint,
-                                  Action<IPEndPoint, Socket> onConnectionEstablished,
-                                  Action<IPEndPoint, SocketError> onConnectionFailed,
+        internal void InitConnect(EndPoint serverEndPoint,
+                                  Action<EndPoint, Socket> onConnectionEstablished,
+                                  Action<EndPoint, SocketError> onConnectionFailed,
                                   ITcpConnection connection,
                                   TimeSpan connectionTimeout)
         {

--- a/src/ReactiveDomain.Transport/TcpConnection.cs
+++ b/src/ReactiveDomain.Transport/TcpConnection.cs
@@ -23,7 +23,7 @@ namespace ReactiveDomain.Transport
                                                                                    () => new SocketAsyncEventArgs());
 
         public static ITcpConnection CreateConnectingTcpConnection(Guid connectionId, 
-                                                                   IPEndPoint remoteEndPoint, 
+                                                                   EndPoint remoteEndPoint, 
                                                                    TcpClientConnector connector, 
                                                                    TimeSpan connectionTimeout,
                                                                    Action<ITcpConnection> onConnectionEstablished, 
@@ -77,7 +77,7 @@ namespace ReactiveDomain.Transport
 
         private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
 
-        private TcpConnection(Guid connectionId, IPEndPoint remoteEndPoint, bool verbose): base(remoteEndPoint)
+        private TcpConnection(Guid connectionId, EndPoint remoteEndPoint, bool verbose): base(remoteEndPoint)
         {
             Ensure.NotEmptyGuid(connectionId, "connectionId");
 

--- a/src/ReactiveDomain.Transport/TcpConnectionBase.cs
+++ b/src/ReactiveDomain.Transport/TcpConnectionBase.cs
@@ -8,8 +8,8 @@ namespace ReactiveDomain.Transport
 {
     public class TcpConnectionBase : IMonitoredTcpConnection
     {
-        public IPEndPoint RemoteEndPoint { get { return _remoteEndPoint; } }
-        public IPEndPoint LocalEndPoint { get { return _localEndPoint; } }
+        public EndPoint RemoteEndPoint { get { return _remoteEndPoint; } }
+        public EndPoint LocalEndPoint { get { return _localEndPoint; } }
 
         public bool IsInitialized { get { return _socket != null; } }
         public bool IsClosed { get { return _isClosed; } }
@@ -92,8 +92,8 @@ namespace ReactiveDomain.Transport
         }
 
         private Socket _socket;
-        private readonly IPEndPoint _remoteEndPoint;
-        private IPEndPoint _localEndPoint;
+        private readonly EndPoint _remoteEndPoint;
+        private EndPoint _localEndPoint;
 
         private long _lastSendStarted = -1;
         private long _lastReceiveStarted = -1;
@@ -110,7 +110,7 @@ namespace ReactiveDomain.Transport
         private int _recvAsyncs;
         private int _recvAsyncCallbacks;
 
-        public TcpConnectionBase(IPEndPoint remoteEndPoint)
+        public TcpConnectionBase(EndPoint remoteEndPoint)
         {
             Ensure.NotNull(remoteEndPoint, "remoteEndPoint");
             _remoteEndPoint = remoteEndPoint;
@@ -123,7 +123,7 @@ namespace ReactiveDomain.Transport
             Ensure.NotNull(socket, "socket");
 
             _socket = socket;
-            _localEndPoint = Helper.EatException(() => (IPEndPoint)socket.LocalEndPoint);
+            _localEndPoint = Helper.EatException(() => socket.LocalEndPoint);
         }
 
         protected void NotifySendScheduled(int bytes)

--- a/src/ReactiveDomain.Transport/TcpConnectionSsl.cs
+++ b/src/ReactiveDomain.Transport/TcpConnectionSsl.cs
@@ -20,7 +20,7 @@ namespace ReactiveDomain.Transport
         private static readonly ILogger Log = LogManager.GetLogger("ReactiveDomain");
 
         public static ITcpConnection CreateConnectingConnection(Guid connectionId, 
-                                                                IPEndPoint remoteEndPoint, 
+                                                                EndPoint remoteEndPoint, 
                                                                 string targetHost,
                                                                 bool validateServer,
                                                                 TcpClientConnector connector, 
@@ -95,7 +95,7 @@ namespace ReactiveDomain.Transport
         private bool _validateServer;
         private readonly byte[] _receiveBuffer = new byte[TcpConnection.BufferManager.ChunkSize];
 
-        private TcpConnectionSsl(Guid connectionId, IPEndPoint remoteEndPoint, bool verbose): base(remoteEndPoint)
+        private TcpConnectionSsl(Guid connectionId, EndPoint remoteEndPoint, bool verbose): base(remoteEndPoint)
         {
             Ensure.NotEmptyGuid(connectionId, "connectionId");
 

--- a/src/ReactiveDomain.Transport/TcpServerListener.cs
+++ b/src/ReactiveDomain.Transport/TcpServerListener.cs
@@ -12,12 +12,12 @@ namespace ReactiveDomain.Transport
     {
         private static readonly ILogger Log = LogManager.GetLogger("ReactiveDomain");
 
-        private readonly IPEndPoint _serverEndPoint;
+        private readonly EndPoint _serverEndPoint;
         private readonly Socket _listeningSocket;
         private readonly SocketArgsPool _acceptSocketArgsPool;
         private Action<IPEndPoint, Socket> _onSocketAccepted;
 
-        public TcpServerListener(IPEndPoint serverEndPoint)
+        public TcpServerListener(EndPoint serverEndPoint)
         {
             Ensure.NotNull(serverEndPoint, "serverEndPoint");
 

--- a/src/ReactiveDomain.Transport/TcpTypedConnection.cs
+++ b/src/ReactiveDomain.Transport/TcpTypedConnection.cs
@@ -23,8 +23,8 @@ namespace ReactiveDomain.Transport
 
         private Action<TcpTypedConnection<T>, T> _receiveCallback;
 
-        public IPEndPoint RemoteEndPoint { get { return _connection.RemoteEndPoint; } }
-        public IPEndPoint LocalEndPoint { get { return _connection.LocalEndPoint; } }
+        public EndPoint RemoteEndPoint { get { return _connection.RemoteEndPoint; } }
+        public EndPoint LocalEndPoint { get { return _connection.LocalEndPoint; } }
 
         public int SendQueueSize
         {


### PR DESCRIPTION
* Allows using `DnsEndPoint` as well as `IPEndPoint`.
* Minor breaking changes to `ITcpConnection` interface, `TcpBusSide` class where the endpoints are now `EndPoint` instead of `IPEndPoint`.