### PR TITLE
Implement reading a stream backwards, count and Cancel() method

### DIFF
--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -19,30 +19,33 @@ namespace ReactiveDomain.Foundation
         /// The name of the stream being read
         /// </summary>
         string StreamName { get; }
-        
+
         /// <summary>
         /// Reads the events on a named stream
         /// </summary>
         /// <param name="stream">the exact stream name</param>
         /// <param name="checkpoint">start point to listen from</param>
-        /// /// <param name="readBackwards">read the stream backwards</param>
-        void Read(string stream, long? checkpoint = null, bool readBackwards = false);
-        
+        /// <param name="count">The count of items to read</param>
+        /// <param name="readBackwards">read the stream backwards</param>
+        void Read(string stream, long? checkpoint = null, long? count = null, bool readBackwards = false);
+
         /// <summary>
         /// Reads the events on an aggregate root stream
         /// </summary>
         /// <typeparam name="TAggregate">The type of aggregate</typeparam>
         /// <param name="id">the aggregate id</param>
         /// <param name="checkpoint">start point to listen from</param>
+        /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">read the stream backwards</param>
-        void Read<TAggregate>(Guid id, long? checkpoint = null, bool readBackwards = false) where TAggregate : class, IEventSource;
-        
+        void Read<TAggregate>(Guid id, long? checkpoint = null, long? count = null, bool readBackwards = false) where TAggregate : class, IEventSource;
+
         /// <summary>
         /// Reads the events on a Aggregate Category Stream
         /// </summary>
         /// <typeparam name="TAggregate">The type of aggregate</typeparam>
         /// <param name="checkpoint">start point to listen from</param>
+        /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">read the stream backwards</param>
-        void Read<TAggregate>(long? checkpoint = null, bool readBackwards = false) where TAggregate : class, IEventSource;
+        void Read<TAggregate>(long? checkpoint = null, long? count = null, bool readBackwards = false) where TAggregate : class, IEventSource;
     }
 }

--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -28,6 +28,16 @@ namespace ReactiveDomain.Foundation
         /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">read the stream backwards</param>
         void Read(string stream, long? checkpoint = null, long? count = null, bool readBackwards = false);
+        
+        /// <summary>
+        /// By Event Type Projection Reader
+        /// i.e. $et-[MessageType]
+        /// </summary>
+        /// <param name="tMessage">The message type used to generate the stream (projection) name</param>
+        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="count">The count of items to read</param>
+        /// <param name="readBackwards">Read the stream backwards</param>
+        void Read(Type tMessage, long? checkpoint = null, long? count = null, bool readBackwards = false);
 
         /// <summary>
         /// Reads the events on an aggregate root stream

--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -47,5 +47,13 @@ namespace ReactiveDomain.Foundation
         /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">read the stream backwards</param>
         void Read<TAggregate>(long? checkpoint = null, long? count = null, bool readBackwards = false) where TAggregate : class, IEventSource;
+
+
+        /// <summary>
+        /// Interrupts the reading process. Doesn't guarantee the moment when reading is stopped. For optimization purpose.
+        /// For use in read models when it needs only certain number of events matching some criteria.
+        /// I.e. if model reads stream backward and needs only the last event of particular type in the stream. 
+        /// </summary>
+        void Cancel();
     }
 }

--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace ReactiveDomain.Foundation
 {
-    public interface IStreamReader
+    public interface IStreamReader : IDisposable
     {
         /// <summary>
         /// The Eventstream the Events are read onto

--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -14,7 +14,7 @@ namespace ReactiveDomain.Foundation
         /// <summary>
         /// The ending position of the stream after the read is complete
         /// </summary>
-        long Position { get; }
+        long? Position { get; }
         /// <summary>
         /// The name of the stream being read
         /// </summary>
@@ -51,8 +51,6 @@ namespace ReactiveDomain.Foundation
 
         /// <summary>
         /// Interrupts the reading process. Doesn't guarantee the moment when reading is stopped. For optimization purpose.
-        /// For use in read models when it needs only certain number of events matching some criteria.
-        /// I.e. if model reads stream backward and needs only the last event of particular type in the stream. 
         /// </summary>
         void Cancel();
     }

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -206,10 +206,7 @@ namespace ReactiveDomain.Foundation
         }
         protected virtual void GotEvent(RecordedEvent recordedEvent)
         {
-            if (recordedEvent is ProjectedEvent projectedEvent)
-                Interlocked.Exchange(ref StreamPosition, projectedEvent.ProjectedEventNumber);
-            else
-                Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+            Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
             if (Serializer.Deserialize(recordedEvent) is Message @event)
             {
                 Bus.Publish(@event);

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -206,7 +206,10 @@ namespace ReactiveDomain.Foundation
         }
         protected virtual void GotEvent(RecordedEvent recordedEvent)
         {
-            Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+            if (recordedEvent is ProjectedEvent projectedEvent)
+                Interlocked.Exchange(ref StreamPosition, projectedEvent.ProjectedEventNumber);
+            else
+                Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
             if (Serializer.Deserialize(recordedEvent) is Message @event)
             {
                 Bus.Publish(@event);

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -170,10 +170,7 @@ namespace ReactiveDomain.Foundation
             // do not publish or increase counters if cancelled
             if (_cancelled) return;
 
-            if (recordedEvent is ProjectedEvent projectedEvent)
-                Interlocked.Exchange(ref StreamPosition, projectedEvent.ProjectedEventNumber);
-            else
-                Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+            Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
             
             if (Serializer.Deserialize(recordedEvent) is Message @event)
             {

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -165,7 +165,7 @@ namespace ReactiveDomain.Foundation
         public bool ValidateStreamName(string streamName)
         {
             var currentSlice = _streamStoreConnection.ReadStreamForward(streamName, 0, 1);
-            return !(currentSlice is StreamNotFoundSlice) && !(currentSlice is StreamDeletedSlice);
+            return !(currentSlice is StreamDeletedSlice);
         }
         protected virtual void EventRead(RecordedEvent recordedEvent)
         {

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -47,16 +47,19 @@ namespace ReactiveDomain.Foundation
             Serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             Bus = new InMemoryBus(busName ?? $"{ReaderName} {nameof(EventStream)}");
         }
+
         /// <summary>
         /// By Event Type Projection Reader
         /// i.e. $et-[MessageType]
         /// </summary>
-        /// <param name="tMessage"></param>
-        /// <param name="checkpoint"></param>
-        /// <param name="readBackwards"></param>
+        /// <param name="tMessage">The message type used to generate the stream (projection) name</param>
+        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="count">The count of items to read</param>
+        /// <param name="readBackwards">Read the stream backwards</param>
         public void Read(
             Type tMessage,
             long? checkpoint = null,
+            long? count = null,
             bool readBackwards = false)
         {
             if (!tMessage.IsSubclassOf(typeof(Event)))
@@ -66,22 +69,27 @@ namespace ReactiveDomain.Foundation
             Read(
                 _streamNameBuilder.GenerateForEventType(tMessage.Name),
                checkpoint,
+               count,
                readBackwards);
         }
+
         /// <summary>
         /// By Category Projection Stream Reader
         /// i.e. $ce-[AggregateType]
         /// </summary>
         /// <typeparam name="TAggregate">The Aggregate type used to generate the stream name</typeparam>
-        /// <param name="checkpoint"></param>
-        /// <param name="readBackwards"></param>
+        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="count">The count of items to read</param>
+        /// <param name="readBackwards">Read the stream backwards</param>
         public void Read<TAggregate>(
                         long? checkpoint = null,
-            bool readBackwards = false) where TAggregate : class, IEventSource
+                        long? count = null,
+                        bool readBackwards = false) where TAggregate : class, IEventSource
         {
             Read(
                _streamNameBuilder.GenerateForCategory(typeof(TAggregate)),
                checkpoint,
+               count,
                readBackwards);
         }
 
@@ -90,17 +98,20 @@ namespace ReactiveDomain.Foundation
         /// i.e. [AggregateType]-[id]
         /// </summary>
         /// <typeparam name="TAggregate">The Aggregate type used to generate the stream name</typeparam>
-        /// <param name="id"></param>
-        /// <param name="checkpoint"></param>
-        /// <param name="readBackwards"></param>
+        /// <param name="id">Aggregate id to generate stream name.</param>
+        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="count">The count of items to read</param>
+        /// <param name="readBackwards">Read the stream backwards</param>
         public void Read<TAggregate>(
                         Guid id,
                         long? checkpoint = null,
+                        long? count = null,
                         bool readBackwards = false) where TAggregate : class, IEventSource
         {
             Read(
                 _streamNameBuilder.GenerateForAggregate(typeof(TAggregate), id),
                 checkpoint,
+                count,
                 readBackwards);
         }
 
@@ -108,15 +119,16 @@ namespace ReactiveDomain.Foundation
         /// Named Stream Reader
         /// i.e. [StreamName]
         /// </summary>
-        /// <param name="streamName"></param>
-        /// <param name="checkpoint"></param>
-        /// <param name="readBackwards"></param>
+        /// <param name="streamName">An exact stream name.</param>
+        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="count">The count of items to read</param>
+        /// <param name="readBackwards">Read the stream backwards</param>
         public virtual void Read(
                             string streamName,
                             long? checkpoint = null,
+                            long? count = null,
                             bool readBackwards = false)
         {
-            //if (readBackwards) { throw new NotImplementedException("Cannot read backwards"); }
             if (!ValidateStreamName(streamName))
                 throw new ArgumentException("Stream not found.", streamName);
 

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -166,8 +166,7 @@ namespace ReactiveDomain.Foundation
                 Bus.Publish(@event);
             }
         }
-
-
+        
         public void Cancel()
         {
             _cancelled = true;

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -125,20 +125,12 @@ namespace ReactiveDomain.Foundation
             StreamEventsSlice currentSlice;
             do
             {
-                if (!readBackwards)
-                {
-                    currentSlice = _streamStoreConnection.ReadStreamForward(streamName, sliceStart, ReadPageSize);
+                currentSlice = !readBackwards ? 
+                    _streamStoreConnection.ReadStreamForward(streamName, sliceStart, ReadPageSize) : 
+                    _streamStoreConnection.ReadStreamBackward(streamName, sliceStart, ReadPageSize);
+
                     sliceStart = currentSlice.NextEventNumber;
                     Array.ForEach(currentSlice.Events, EventRead);
-                }
-                else
-                {
-                    currentSlice = _streamStoreConnection.ReadStreamBackward(streamName, sliceStart, ReadPageSize);
-                    sliceStart = currentSlice.NextEventNumber;
-                    Array.ForEach(currentSlice.Events, EventRead);
-                }
-
-
 
             } while (!currentSlice.IsEndOfStream);
         }

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -134,7 +134,7 @@ namespace ReactiveDomain.Foundation
                             bool readBackwards = false)
         {
             if (checkpoint != null)
-                Ensure.Positive((long)checkpoint, nameof(checkpoint));
+                Ensure.Nonnegative((long)checkpoint, nameof(checkpoint));
             if (count != null)
                 Ensure.Positive((long)count, nameof(count));
             if (!ValidateStreamName(streamName))
@@ -170,7 +170,11 @@ namespace ReactiveDomain.Foundation
             // do not publish or increase counters if cancelled
             if (_cancelled) return;
 
-            Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+            if (recordedEvent is ProjectedEvent projectedEvent)
+                Interlocked.Exchange(ref StreamPosition, projectedEvent.ProjectedEventNumber);
+            else
+                Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+            
             if (Serializer.Deserialize(recordedEvent) is Message @event)
             {
                 Bus.Publish(@event);

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamStoreRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamStoreRepository.cs
@@ -98,7 +98,7 @@ namespace ReactiveDomain.Foundation {
 
             StreamEventsSlice streamEventsSlice;
             do {
-                streamEventsSlice = _streamStoreConnection.ReadStreamForward(streamName, start, 500);
+                streamEventsSlice = _streamStoreConnection.ReadStreamForward(streamName, start, ReadPageSize);
                 if (streamEventsSlice is StreamNotFoundSlice)
                     throw new AggregateNotFoundException(id, aggregate.GetType());
                 if (streamEventsSlice is StreamDeletedSlice)

--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
@@ -4,30 +4,36 @@ using System.Linq;
 using System.Threading.Tasks;
 using ES = EventStore.ClientAPI;
 
-namespace ReactiveDomain.EventStore {
-    public class EventStoreConnectionWrapper : IStreamStoreConnection {
+namespace ReactiveDomain.EventStore
+{
+    public class EventStoreConnectionWrapper : IStreamStoreConnection
+    {
         public readonly ES.IEventStoreConnection EsConnection;
         private bool _disposed;
         private const int WriteBatchSize = 500;
 
-        public EventStoreConnectionWrapper(ES.IEventStoreConnection eventStoreConnection) {
+        public EventStoreConnectionWrapper(ES.IEventStoreConnection eventStoreConnection)
+        {
             Ensure.NotNull(eventStoreConnection, nameof(eventStoreConnection));
             EsConnection = eventStoreConnection;
             EsConnection.Connected += ConnOnConnected;
         }
 
         public event EventHandler<ClientConnectionEventArgs> Connected = (p1, p2) => { };
-        private void ConnOnConnected(object sender, ES.ClientConnectionEventArgs clientConnectionEventArgs) {
+        private void ConnOnConnected(object sender, ES.ClientConnectionEventArgs clientConnectionEventArgs)
+        {
             Connected(sender, clientConnectionEventArgs.ToRdEventArgs(this));
         }
 
         public string ConnectionName => EsConnection.ConnectionName;
 
-        public void Connect() {
+        public void Connect()
+        {
             EsConnection.ConnectAsync().Wait();
         }
 
-        public void Close() {
+        public void Close()
+        {
             EsConnection.Close();
         }
 
@@ -36,15 +42,19 @@ namespace ReactiveDomain.EventStore {
                             string stream,
                             long expectedVersion,
                             UserCredentials credentials = null,
-                            params EventData[] events) {
-            try {
-                if (events.Length < WriteBatchSize) {
+                            params EventData[] events)
+        {
+            try
+            {
+                if (events.Length < WriteBatchSize)
+                {
                     return EsConnection.AppendToStreamAsync(stream, (int)expectedVersion, events.ToESEventData(), credentials.ToESCredentials()).Result.ToWriteResult();
                 }
 
                 var transaction = EsConnection.StartTransactionAsync(stream, (int)expectedVersion).Result;
                 var position = 0;
-                while (position < events.Length) {
+                while (position < events.Length)
+                {
                     var pageEvents = events.Skip(position).Take(WriteBatchSize).ToArray();
                     transaction.WriteAsync(pageEvents.ToESEventData()).Wait();
                     position += WriteBatchSize;
@@ -52,23 +62,27 @@ namespace ReactiveDomain.EventStore {
 
                 return transaction.CommitAsync().Result.ToWriteResult();
             }
-            catch (AggregateException ex) {
-                if (ex.InnerException is ES.Exceptions.WrongExpectedVersionException ) {
+            catch (AggregateException ex)
+            {
+                if (ex.InnerException is ES.Exceptions.WrongExpectedVersionException)
+                {
                     throw new WrongExpectedVersionException(ex.InnerException.Message, ex.InnerException);
                 }
                 throw;
             }
-                
+
         }
 
         public StreamEventsSlice ReadStreamForward(
                                     string stream,
                                     long start,
                                     long count,
-                                    UserCredentials credentials = null) {
+                                    UserCredentials credentials = null)
+        {
             //todo: why does this need an int with v 4.0 of eventstore?
             var slice = EsConnection.ReadStreamEventsForwardAsync(stream, (int)start, (int)count, true, credentials.ToESCredentials()).Result;
-            switch (slice.Status) {
+            switch (slice.Status)
+            {
                 case ES.SliceReadStatus.Success:
                     return slice.ToStreamEventsSlice();
                 case ES.SliceReadStatus.StreamNotFound:
@@ -84,10 +98,12 @@ namespace ReactiveDomain.EventStore {
                                     string stream,
                                     long start,
                                     long count,
-                                    UserCredentials credentials = null) {
+                                    UserCredentials credentials = null)
+        {
             //todo: why does this need an int with v 4.0 of eventstore?
             var slice = EsConnection.ReadStreamEventsBackwardAsync(stream, (int)start, (int)count, true, credentials.ToESCredentials()).Result;
-            switch (slice.Status) {
+            switch (slice.Status)
+            {
                 case ES.SliceReadStatus.Success:
                     return slice.ToStreamEventsSlice();
                 case ES.SliceReadStatus.StreamNotFound:
@@ -103,14 +119,16 @@ namespace ReactiveDomain.EventStore {
                                     string stream,
                                     Action<RecordedEvent> eventAppeared,
                                     Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-                                    UserCredentials userCredentials = null) {
+                                    UserCredentials userCredentials = null)
+        {
             var sub = EsConnection.SubscribeToStreamAsync(
                                 stream,
                                 true,
-                                async (_, evt) => { eventAppeared(evt.Event.ToRecordedEvent()); await Task.FromResult(Unit.Default); },
+                                async (_, evt) => { eventAppeared(evt.Event.ToRecordedEvent(evt.OriginalEvent.EventNumber)); await Task.FromResult(Unit.Default); },
                                 (_, reason, ex) => subscriptionDropped?.Invoke((SubscriptionDropReason)(int)reason, ex),
                                 userCredentials?.ToESCredentials()).Result;
-            return new Disposer(() => {
+            return new Disposer(() =>
+            {
                 sub?.Unsubscribe();
                 sub?.Dispose();
                 return Unit.Default;
@@ -124,61 +142,69 @@ namespace ReactiveDomain.EventStore {
                                             Action<RecordedEvent> eventAppeared,
                                             Action<Unit> liveProcessingStarted = null,
                                             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-                                            UserCredentials userCredentials = null) {
+                                            UserCredentials userCredentials = null)
+        {
             var sub = EsConnection.SubscribeToStreamFrom(
                                             stream,
                                             (int?)lastCheckpoint,
                                             settings?.ToCatchUpSubscriptionSettings() ?? ES.CatchUpSubscriptionSettings.Default,
-                                            async (_, evt) => { eventAppeared(evt.Event.ToRecordedEvent()); await Task.FromResult(Unit.Default); },
+                                            async (_, evt) => { eventAppeared(evt.Event.ToRecordedEvent(evt.OriginalEvent.EventNumber)); await Task.FromResult(Unit.Default); },
                                             _ => liveProcessingStarted?.Invoke(Unit.Default),
                                             (_, reason, ex) => subscriptionDropped?.Invoke((SubscriptionDropReason)(int)reason, ex),
                                             userCredentials?.ToESCredentials());
 
-            return new Disposer(() => {
+            return new Disposer(() =>
+            {
                 sub?.Stop();
                 return Unit.Default;
             });
         }
-        
+
         public IDisposable SubscribeToAll(
             Action<RecordedEvent> eventAppeared,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
-            bool resolveLinkTos = true) {
+            bool resolveLinkTos = true)
+        {
             var sub = EsConnection.SubscribeToAllAsync(
                 resolveLinkTos,
-                async (_, evt) => {
+                async (_, evt) =>
+                {
                     eventAppeared(evt.Event.ToRecordedEvent());
                     await Task.FromResult(Unit.Default);
                 },
                 (_, reason, ex) => subscriptionDropped?.Invoke((SubscriptionDropReason)(int)reason, ex),
                 userCredentials?.ToESCredentials()).Result;
-            return new Disposer(() => {
+            return new Disposer(() =>
+            {
                 sub?.Unsubscribe();
                 sub?.Dispose();
                 return Unit.Default;
             });
         }
-    
+
         public IDisposable SubscribeToAllFrom(
             Position from,
             Action<RecordedEvent> eventAppeared,
-            CatchUpSubscriptionSettings settings = null, 
-            Action liveProcessingStarted = null, 
+            CatchUpSubscriptionSettings settings = null,
+            Action liveProcessingStarted = null,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
-            bool resolveLinkTos = true) {
+            bool resolveLinkTos = true)
+        {
             var sub = EsConnection.SubscribeToAllFrom(
                 new ES.Position(from.CommitPosition, from.PreparePosition),
                 settings?.ToCatchUpSubscriptionSettings(),
-                async (_, evt) => {
+                async (_, evt) =>
+                {
                     eventAppeared(evt.Event.ToRecordedEvent());
                     await Task.FromResult(Unit.Default);
                 },
                 __ => { liveProcessingStarted?.Invoke(); },
-                (_, reason, ex) => subscriptionDropped?.Invoke((SubscriptionDropReason) (int) reason, ex),
+                (_, reason, ex) => subscriptionDropped?.Invoke((SubscriptionDropReason)(int)reason, ex),
                 userCredentials?.ToESCredentials());
-            return new Disposer(() => {
+            return new Disposer(() =>
+            {
                 sub.Stop(TimeSpan.FromMilliseconds(250));
                 return Unit.Default;
             });
@@ -187,9 +213,12 @@ namespace ReactiveDomain.EventStore {
 
         public void DeleteStream(string stream, int expectedVersion, UserCredentials credentials = null)
                         => EsConnection.DeleteStreamAsync(stream, expectedVersion, credentials.ToESCredentials()).Wait();
-        public void Dispose() {
-            if (!_disposed) {
-                if (EsConnection != null) {
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                if (EsConnection != null)
+                {
                     EsConnection.Close();
                     EsConnection.Connected -= ConnOnConnected;
                     EsConnection.Dispose();
@@ -199,21 +228,26 @@ namespace ReactiveDomain.EventStore {
         }
     }
 
-    public static class ConnectionHelpers {
-        public static WriteResult ToWriteResult(this ES.WriteResult result) {
+    public static class ConnectionHelpers
+    {
+        public static WriteResult ToWriteResult(this ES.WriteResult result)
+        {
             return new WriteResult(result.NextExpectedVersion);
         }
-        public static ES.SystemData.UserCredentials ToESCredentials(this UserCredentials credentials) {
+        public static ES.SystemData.UserCredentials ToESCredentials(this UserCredentials credentials)
+        {
             return credentials == null ?
                 null :
                 new ES.SystemData.UserCredentials(credentials.Username, credentials.Password);
         }
 
-        public static ClientConnectionEventArgs ToRdEventArgs(this ES.ClientConnectionEventArgs args, IStreamStoreConnection conn) {
+        public static ClientConnectionEventArgs ToRdEventArgs(this ES.ClientConnectionEventArgs args, IStreamStoreConnection conn)
+        {
             return new ClientConnectionEventArgs(conn, args.RemoteEndPoint);
         }
 
-        public static StreamEventsSlice ToStreamEventsSlice(this ES.StreamEventsSlice slice) {
+        public static StreamEventsSlice ToStreamEventsSlice(this ES.StreamEventsSlice slice)
+        {
             return new StreamEventsSlice(
                     slice.Stream,
                     slice.FromEventNumber,
@@ -224,20 +258,25 @@ namespace ReactiveDomain.EventStore {
                     slice.IsEndOfStream);
         }
 
-        public static RecordedEvent[] ToRecordedEvents(this ES.ResolvedEvent[] resolvedEvents) {
+        public static RecordedEvent[] ToRecordedEvents(this ES.ResolvedEvent[] resolvedEvents)
+        {
             Ensure.NotNull(resolvedEvents, nameof(resolvedEvents));
             var events = new RecordedEvent[resolvedEvents.Length];
-            for (int i = 0; i < resolvedEvents.Length; i++) {
-                events[i] = resolvedEvents[i].OriginalEvent.ToRecordedEvent();
+            for (int i = 0; i < resolvedEvents.Length; i++)
+            {
+                var evt = resolvedEvents[i].Event;
+                //we want the event number from the stream we're reading not the original stream
+                events[i] = evt.ToRecordedEvent(resolvedEvents[i].OriginalEvent.EventNumber);
             }
             return events;
         }
 
-        public static RecordedEvent ToRecordedEvent(this ES.RecordedEvent recordedEvent) {
+        public static RecordedEvent ToRecordedEvent(this ES.RecordedEvent recordedEvent, long? eventNumber = null)
+        {
             return new RecordedEvent(
                 recordedEvent.EventStreamId,
                 recordedEvent.EventId,
-                recordedEvent.EventNumber,
+                eventNumber ?? recordedEvent.EventNumber,
                 recordedEvent.EventType,
                 recordedEvent.Data,
                 recordedEvent.Metadata,
@@ -246,15 +285,18 @@ namespace ReactiveDomain.EventStore {
                 recordedEvent.CreatedEpoch);
         }
 
-        public static ES.EventData[] ToESEventData(this EventData[] events) {
+        public static ES.EventData[] ToESEventData(this EventData[] events)
+        {
             Ensure.NotNull(events, nameof(events));
             var result = new ES.EventData[events.Length];
-            for (int i = 0; i < events.Length; i++) {
+            for (int i = 0; i < events.Length; i++)
+            {
                 result[i] = events[i].ToESEventData();
             }
             return result;
         }
-        public static ES.EventData ToESEventData(this EventData @event) {
+        public static ES.EventData ToESEventData(this EventData @event)
+        {
             Ensure.NotNull(@event, nameof(@event));
             return new ES.EventData(
                             @event.EventId,
@@ -264,8 +306,10 @@ namespace ReactiveDomain.EventStore {
                             @event.Metadata);
         }
 
-        public static ReadDirection ToReadDirection(this ES.ReadDirection readDirection) {
-            switch (readDirection) {
+        public static ReadDirection ToReadDirection(this ES.ReadDirection readDirection)
+        {
+            switch (readDirection)
+            {
                 case ES.ReadDirection.Forward:
                     return ReadDirection.Forward;
                 case ES.ReadDirection.Backward:
@@ -275,7 +319,8 @@ namespace ReactiveDomain.EventStore {
             }
         }
 
-        public static ES.CatchUpSubscriptionSettings ToCatchUpSubscriptionSettings(this CatchUpSubscriptionSettings settings) {
+        public static ES.CatchUpSubscriptionSettings ToCatchUpSubscriptionSettings(this CatchUpSubscriptionSettings settings)
+        {
             if (null == settings)
                 return null;
 #if NET452

--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
@@ -228,7 +228,7 @@ namespace ReactiveDomain.EventStore {
             Ensure.NotNull(resolvedEvents, nameof(resolvedEvents));
             var events = new RecordedEvent[resolvedEvents.Length];
             for (int i = 0; i < resolvedEvents.Length; i++) {
-                events[i] = resolvedEvents[i].Event.ToRecordedEvent();
+                events[i] = resolvedEvents[i].OriginalEvent.ToRecordedEvent();
             }
             return events;
         }

--- a/src/ReactiveDomain.Persistence/ProjectedEvent.cs
+++ b/src/ReactiveDomain.Persistence/ProjectedEvent.cs
@@ -4,11 +4,11 @@ namespace ReactiveDomain {
     public class ProjectedEvent:RecordedEvent
     {
         public string ProjectedStream;
-        public long ProjectedEventNumber;
+        public long OriginalEventNumber;
 
         public ProjectedEvent(
                 string projectedStream,
-                long projectedEventNumber,
+                long originalEventNumber,
                 string eventStreamId,
                 Guid eventId,
                 long eventNumber,
@@ -28,7 +28,7 @@ namespace ReactiveDomain {
                                         created,
                                         createdEpoch) {
             ProjectedStream = projectedStream;
-            ProjectedEventNumber = projectedEventNumber;
+            OriginalEventNumber = originalEventNumber;
         }
     }
 }

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
@@ -169,7 +169,7 @@ namespace ReactiveDomain.Testing.EventStore {
                                     long start,
                                     long count,
                                     UserCredentials credentials = null) {
-            if (start < -1) throw new ArgumentOutOfRangeException($"{nameof(start)} must be positve or -1 for reading from the end of the stream.");
+            if (start < -1) throw new ArgumentOutOfRangeException($"{nameof(start)} must be non-negative or -1 for reading from the end of the stream.");
             List<RecordedEvent> stream;
             lock (_store) {
                 if (!_store.ContainsKey(streamName)) { return new StreamNotFoundSlice(streamName); }

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
@@ -397,10 +397,10 @@ namespace ReactiveDomain.Testing.EventStore {
 
             var projectedEvent = new ProjectedEvent(
                     streamName,
-                    stream.Count,
+                    @event.Event.EventNumber,
                     @event.Event.EventStreamId,
                     @event.Event.EventId, // reusing since the projection is linking to the original event
-                    @event.Event.EventNumber,
+                    stream.Count,
                     @event.Event.EventType,
                     @event.Event.Data,
                     @event.Event.Metadata,
@@ -409,7 +409,7 @@ namespace ReactiveDomain.Testing.EventStore {
                     epochTime);
             stream.Add(projectedEvent);
             All.Add(projectedEvent);
-            _inboundEventHandler.Handle(new EventWritten(streamName, projectedEvent, true, projectedEvent.ProjectedEventNumber));
+            _inboundEventHandler.Handle(new EventWritten(streamName, projectedEvent, true, projectedEvent.EventNumber));
         }
 
         /// <summary>
@@ -434,10 +434,10 @@ namespace ReactiveDomain.Testing.EventStore {
 
             var projectedEvent = new ProjectedEvent(
                 streamName,
-                stream.Count,
+                @event.Event.EventNumber,
                 @event.Event.EventStreamId,
                 @event.Event.EventId, // reusing since the projection is linking to the original event
-                @event.Event.EventNumber,
+                stream.Count,
                 @event.Event.EventType,
                 @event.Event.Data,
                 @event.Event.Metadata,
@@ -446,7 +446,7 @@ namespace ReactiveDomain.Testing.EventStore {
                 epochTime);
             stream.Add(projectedEvent);
             All.Add(projectedEvent);
-            _inboundEventHandler.Handle(new EventWritten(streamName, projectedEvent, true, projectedEvent.ProjectedEventNumber));
+            _inboundEventHandler.Handle(new EventWritten(streamName, projectedEvent, true, projectedEvent.EventNumber));
         }
 
 

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
@@ -169,7 +169,7 @@ namespace ReactiveDomain.Testing.EventStore {
                                     long start,
                                     long count,
                                     UserCredentials credentials = null) {
-            if (start < 0) throw new ArgumentOutOfRangeException($"{nameof(start)} must be positve.");
+            if (start < -1) throw new ArgumentOutOfRangeException($"{nameof(start)} must be positve or -1 for reading from the end of the stream.");
             List<RecordedEvent> stream;
             lock (_store) {
                 if (!_store.ContainsKey(streamName)) { return new StreamNotFoundSlice(streamName); }
@@ -184,7 +184,7 @@ namespace ReactiveDomain.Testing.EventStore {
                                     List<RecordedEvent> stream,
                                     ReadDirection direction) {
             var result = new List<RecordedEvent>();
-            var next = (int)start;
+            var next = start == -1 ? stream.Count - 1 : (int)start;
             for (int i = 0; i < count; i++) {
                 if (next < stream.Count && next >= 0) {
                     long current = next;

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -77,9 +77,16 @@ namespace ReactiveDomain.Testing.EventStore
                 _count = 0;
                 var reader = new StreamReader("TestReader", conn, _streamNameBuilder, _serializer);
                 reader.EventStream.Subscribe<Event>(this);
+                // forward 1 from beginning
+                _count = 0;
+                Assert.Null(reader.Position);
+                reader.Read(_streamName, count: 1);
+                Assert.Equal(1, _count);
+                Assert.Equal(0, reader.Position);
 
+                // forward all
+                _count = 0;
                 reader.Read(_streamName);
-
                 Assert.Equal(NUM_OF_EVENTS, _count);
             }
         }
@@ -318,11 +325,19 @@ namespace ReactiveDomain.Testing.EventStore
                 Thread.Sleep(100);
                 reader.EventStream.Subscribe<Event>(this);
 
+                // forward 1 from beginning
+                _count = 0;
+                Assert.Null(reader.Position);
+                reader.Read(categoryStream, count: 1);
+                Assert.Equal(1, _count);
+                Assert.Equal(0, reader.Position);
+
                 // forward 2 from beginning
                 _count = 0;
                 reader.Read(categoryStream, count: 2);
                 Assert.Equal(2, _count);
                 Assert.Equal(1, reader.Position);
+                
                 
                 // forward 2 from 12
                 _count = 0;

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -30,7 +30,7 @@ namespace ReactiveDomain.Testing.EventStore
             var mockStreamStore = new MockStreamStoreConnection("Test-" + Guid.NewGuid());
             mockStreamStore.Connect();
 
-            _stores.Add(mockStreamStore);
+            //_stores.Add(mockStreamStore);
             _stores.Add(fixture.Connection);
 
             _streamName = _streamNameBuilder.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
@@ -326,18 +326,17 @@ namespace ReactiveDomain.Testing.EventStore
                 Assert.Equal(1, reader.Position);
 
 
+                // forward 2 from 12
+                _count = 0;
+                reader.Read(categoryStream, checkpoint: 12, count: 2);
+                Assert.Equal(2, _count);
+                Assert.Equal(13, reader.Position);
+
                 // forward 10 from 5
                 _count = 0;
                 reader.Read(categoryStream, checkpoint: 5, count: 10);
                 Assert.Equal(10, _count);
                 Assert.Equal(14, reader.Position);
-                
-                // backward all
-                //_count = 0;
-                //reader.Read(categoryStream, readBackwards: true);
-                //Assert.Equal(2 * NUM_OF_EVENTS, _count);
-                //Assert.Equal(0, reader.Position);
-
 
                 // backward 5 from 10
                 _count = 0;

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
+// ReSharper disable UnusedParameter.Local
+
 namespace ReactiveDomain.Testing.EventStore
 {
     public class StreamReaderTests : IClassFixture<StreamStoreConnectionFixture>, Messaging.Bus.IHandle<Event>
@@ -18,7 +20,7 @@ namespace ReactiveDomain.Testing.EventStore
         private readonly IStreamNameBuilder _streamNameBuilder;
         private long _count;
         private readonly int NUM_OF_EVENTS = 10;
-        private ITestOutputHelper _toh;
+        private readonly ITestOutputHelper _toh;
         private Action<Event> _gotEvent;
 
         public StreamReaderTests(ITestOutputHelper toh, StreamStoreConnectionFixture fixture)
@@ -37,13 +39,13 @@ namespace ReactiveDomain.Testing.EventStore
             foreach (var store in _stores)
             {
                 AppendEvents(NUM_OF_EVENTS, store, _streamName);
-
             }
         }
 
         private void AppendEvents(int numEventsToBeSent, IStreamStoreConnection conn, string streamName)
         {
-            _toh.WriteLine($"Appending {numEventsToBeSent} events to stream \"{streamName}\" with connection {conn.ConnectionName}");
+            _toh.WriteLine(
+                $"Appending {numEventsToBeSent} events to stream \"{streamName}\" with connection {conn.ConnectionName}");
 
             for (int evtNumber = 0; evtNumber < numEventsToBeSent; evtNumber++)
             {
@@ -54,7 +56,8 @@ namespace ReactiveDomain.Testing.EventStore
 
         private void AppendEventArray(int numEventsToBeSent, IStreamStoreConnection conn, string streamName)
         {
-            _toh.WriteLine($"Appending {numEventsToBeSent} events to stream \"{streamName}\" with connection {conn.ConnectionName}");
+            _toh.WriteLine(
+                $"Appending {numEventsToBeSent} events to stream \"{streamName}\" with connection {conn.ConnectionName}");
 
             var events = new Event[numEventsToBeSent];
             for (int evtNumber = 0; evtNumber < numEventsToBeSent; evtNumber++)
@@ -62,7 +65,8 @@ namespace ReactiveDomain.Testing.EventStore
                 events[evtNumber] = new ReadTestEvent(evtNumber);
             }
 
-            conn.AppendToStream(streamName, ExpectedVersion.Any, null, events.Select(x => _serializer.Serialize(x)).ToArray());
+            conn.AppendToStream(streamName, ExpectedVersion.Any, null,
+                events.Select(x => _serializer.Serialize(x)).ToArray());
         }
 
         [Fact]
@@ -113,7 +117,6 @@ namespace ReactiveDomain.Testing.EventStore
         }
 
 
-
         [Fact]
         public void cannot_read_non_existing_stream()
         {
@@ -123,10 +126,7 @@ namespace ReactiveDomain.Testing.EventStore
 
                 reader.EventStream.Subscribe<Event>(this);
 
-                Assert.Throws<ArgumentException>(() =>
-                {
-                    reader.Read("missing_stream");
-                });
+                Assert.Throws<ArgumentException>(() => { reader.Read("missing_stream"); });
             }
         }
 
@@ -142,15 +142,14 @@ namespace ReactiveDomain.Testing.EventStore
                 Parallel.Invoke(
                     () =>
                     {
-                        for (int chunkNum = 0; chunkNum < 10; chunkNum++) 
+                        for (int chunkNum = 0; chunkNum < 10; chunkNum++)
                             AppendEventArray(NUM_OF_EVENTS, conn, _streamName);
                     },
                     () => reader.Read(_streamName)
-                    );
+                );
 
                 _toh.WriteLine($"Read events: {_count}");
                 Assert.Equal(0, _count % NUM_OF_EVENTS);
-                
             }
         }
 
@@ -200,10 +199,7 @@ namespace ReactiveDomain.Testing.EventStore
                 reader.EventStream.Subscribe<Event>(this);
 
                 var events = new List<ReadTestEvent>(TotalEvents);
-                _gotEvent = evt =>
-                {
-                    events.Add(evt as ReadTestEvent);
-                };
+                _gotEvent = evt => { events.Add(evt as ReadTestEvent); };
                 reader.Read(longStreamName, readBackwards: true);
 
                 Assert.Equal(TotalEvents, _count);
@@ -227,6 +223,7 @@ namespace ReactiveDomain.Testing.EventStore
         public class ReadTestEvent : Event
         {
             public readonly int MessageNumber;
+
             public ReadTestEvent(
                 int messageNumber
             ) : base(NewRoot())

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -234,7 +234,7 @@ namespace ReactiveDomain.Testing.EventStore
                 reader.Read(longStreamName);
 
                 _toh.WriteLine($"Read events: {_count} out of {ManyEvents}, cancelled >= #100");
-                Assert.InRange(_count, 100, 150);
+                Assert.Equal(101, _count); // counter increased after cancellation  - expected 101
 
                 // reset
                 _count = 0;
@@ -243,7 +243,7 @@ namespace ReactiveDomain.Testing.EventStore
                 reader.Read(longStreamName, readBackwards: true);
 
                 _toh.WriteLine($"Read events: {_count} out of {ManyEvents}, cancelled >= #100");
-                Assert.InRange(_count, 100, 150);
+                Assert.Equal(101, _count);
 
             }
         }

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -153,9 +153,57 @@ namespace ReactiveDomain.Testing.EventStore
             }
         }
 
+        [Fact]
+        public void can_read_stream_backward()
+        {
+            foreach (var conn in _stores)
+            {
+                var reader = new StreamReader("TestReader", conn, _streamNameBuilder, _serializer);
+
+                reader.EventStream.Subscribe<Event>(this);
+
+                reader.Read(_streamName, readBackwards: true);
+
+                Assert.Equal(NUM_OF_EVENTS, _count);
+            }
+        }
+
+        [Fact]
+        public void can_read_stream_backward_from_position()
+        {
+            foreach (var conn in _stores)
+            {
+                var reader = new StreamReader("TestReader", conn, _streamNameBuilder, _serializer);
+
+                var position = NUM_OF_EVENTS / 2;
+
+                reader.EventStream.Subscribe<Event>(this);
+
+                reader.Read(_streamName, position, readBackwards: true);
+
+                Assert.Equal(position + 1, _count); // events from positions: N, N-1...0 => N+1 events
+            }
+        }
+
+        [Fact(Skip = "wip, not implemented yet")]
+        public void can_read_stream_backward_multiple_slices()
+        {
+            foreach (var conn in _stores)
+            {
+                var reader = new StreamReader("TestReader", conn, _streamNameBuilder, _serializer);
+
+                reader.EventStream.Subscribe<Event>(this);
+
+                reader.Read(_streamName, readBackwards: true);
+
+                Assert.Equal(NUM_OF_EVENTS, _count);
+            }
+        }
+
+
         public void Handle(Event message)
         {
-            Thread.Sleep(new Random().Next(300)); // random event handling time
+            //Thread.Sleep(new Random().Next(300)); // random event handling time
             Interlocked.Increment(ref _count);
         }
 

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -30,7 +30,7 @@ namespace ReactiveDomain.Testing.EventStore
             var mockStreamStore = new MockStreamStoreConnection("Test-" + Guid.NewGuid());
             mockStreamStore.Connect();
 
-            //_stores.Add(mockStreamStore);
+            _stores.Add(mockStreamStore);
             _stores.Add(fixture.Connection);
 
             _streamName = _streamNameBuilder.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
@@ -89,10 +89,9 @@ namespace ReactiveDomain.Testing.EventStore
         {
             foreach (var conn in _stores)
             {
+                _count = 0;
                 var reader = new StreamReader("TestReader", conn, _streamNameBuilder, _serializer);
-
                 var position = NUM_OF_EVENTS / 2;
-
                 reader.EventStream.Subscribe<Event>(this);
 
                 reader.Read(_streamName, position);
@@ -324,8 +323,7 @@ namespace ReactiveDomain.Testing.EventStore
                 reader.Read(categoryStream, count: 2);
                 Assert.Equal(2, _count);
                 Assert.Equal(1, reader.Position);
-
-
+                
                 // forward 2 from 12
                 _count = 0;
                 reader.Read(categoryStream, checkpoint: 12, count: 2);

--- a/src/ReactiveDomain.Testing/EventStore/StreamStoreReadTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamStoreReadTests.cs
@@ -271,7 +271,7 @@ namespace ReactiveDomain.Testing.EventStore {
                     startFrom,
                     count);
                 expectedCount = 2;
-                Assert.True(expectedCount == slice.Events.Length, "Failed to read events forward");
+                Assert.True(expectedCount == slice.Events.Length, "Failed to read events backward");
                 Assert.Equal(startFrom, slice.FromEventNumber);
                 Assert.Equal(_lastEvent, slice.LastEventNumber);
                 Assert.Equal(startFrom - count, slice.NextEventNumber);
@@ -292,7 +292,7 @@ namespace ReactiveDomain.Testing.EventStore {
                     startFrom,
                     count);
                 expectedCount = 0;
-                Assert.True(expectedCount == slice.Events.Length, "Failed to read events forward");
+                Assert.True(expectedCount == slice.Events.Length, "Failed to read events backward");
                 Assert.Equal(startFrom, slice.FromEventNumber);
                 Assert.Equal(_lastEvent, slice.LastEventNumber);
                 Assert.Equal(_lastEvent, slice.NextEventNumber);


### PR DESCRIPTION
- use ReadPageSize instead of hardcoded values
- initial implementation of StreamReader.ReadStreamBackwards
- changes in mock infrastructure to support backward reading (-1 as default value to start from the last event in the stream)
- implemented count parameter in Read(..) methods 
- implemented Cancel() method
- tests
